### PR TITLE
chore(deps): bump undici to 8.5.0 (fix 5 CVEs)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11860,9 +11860,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
-      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -90,6 +90,6 @@
   "overrides": {
     "minimatch": ">=3.1.3",
     "tmp": ">=0.2.6",
-    "undici": ">=6.24.0"
+    "undici": ">=8.5.0"
   }
 }


### PR DESCRIPTION
## CVE fix: undici

| Package | Severity | Advisory | Current → Patched | Breaking? |
|---|---|---|---|---|
| undici | high | GHSA-vxpw-j846-p89q / CVE-2026-12151 | 8.3.0 → 8.5.0 | no |
| undici | high | GHSA-vmh5-mc38-953g / CVE-2026-9697 | 8.3.0 → 8.5.0 | no |
| undici | high | GHSA-38rv-x7px-6hhq / CVE-2026-9675 | 8.3.0 → 8.5.0 | no |
| undici | medium | GHSA-p88m-4jfj-68fv / CVE-2026-9679 | 8.3.0 → 8.5.0 | no |
| undici | medium | GHSA-pr7r-676h-xcf6 / CVE-2026-9678 | 8.3.0 → 8.5.0 | no |

### Risk
Three high-severity undici vulnerabilities: two WebSocket DoS via fragment count/cumulative bypass, and one TLS certificate validation bypass via dropped `requestTls` in SOCKS5 ProxyAgent. Two medium issues: HTTP header injection via Set-Cookie percent-decoding, and cross-user information disclosure via shared cache whitespace bypass.

### Affected scope
- **Runtime impact**: yes (undici is a `runtime` transitive dep)
- **Affected service / command / API / job**: GitHub Actions runner — undici is pulled in by `@actions/http-client` which underpins `@actions/github` and `@actions/core` HTTP calls
- **Reachability**: transitive via `@actions/http-client`; the WebSocket paths (DoS vulns) are not directly invoked by this action, but the TLS bypass and header injection affect any HTTP/HTTPS request made during action execution

### Breaking change
None. This is a patch/minor bump within the same major (8.3.0 → 8.5.0). The `overrides.undici` entry in `package.json` was tightened from `>=6.24.0` to `>=8.5.0` to force the lockfile to resolve to the patched version.

### How to test
1. `npm install` — confirm `node_modules/undici` resolves to `>=8.5.0`
2. Run the action end-to-end in a test workflow to confirm caching still works
3. `npm test` for unit tests

Fixes Dependabot alerts #130, #131, #132, #137, #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)